### PR TITLE
Fix CORS errors for same endpoints but different methods

### DIFF
--- a/backend/cmd/app/main.go
+++ b/backend/cmd/app/main.go
@@ -59,27 +59,108 @@ func main() {
 	})
 
 	//Student routes
-	stdMux.HandleFunc("POST /api/students", handlers.CreateStudentHandler(studentService))
-	stdMux.HandleFunc("GET /api/students", handlers.GetStudentsHandler(studentService))
-	stdMux.HandleFunc("GET /api/students/{username}", handlers.GetStudentHandler(studentService))
-	stdMux.HandleFunc("PUT /api/students/{username}", handlers.UpdateStudentHandler(studentService))
-	stdMux.HandleFunc("DELETE /api/students/{username}", handlers.DeleteStudentHandler(studentService, userSessionService))
-	stdMux.HandleFunc("GET /api/students/{studentID}/courses", handlers.GetStudentsCoursesHandler(enrollmentsService))
-	stdMux.HandleFunc("POST /api/students/{studentID}/majors", handlers.AddStudentToMajorHandler(studentService))
+	stdMux.HandleFunc("/api/students", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.CreateStudentHandler(studentService, w, r)
+		case http.MethodGet:
+			handlers.GetStudentsHandler(studentService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/students/{username}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.GetStudentHandler(studentService, w, r)
+		case http.MethodPut:
+			handlers.UpdateStudentHandler(studentService, w, r)
+		case http.MethodDelete:
+			handlers.DeleteStudentHandler(studentService, userSessionService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/students/{studentID}/courses", handlers.GetStudentsCoursesHandler(enrollmentsService))
+	stdMux.HandleFunc("/api/students/{studentID}/majors", handlers.AddStudentToMajorHandler(studentService))
 
 	//Teacher routes
-	stdMux.HandleFunc("POST /api/teachers", handlers.CreateTeacherHandler(teacherService))
-	stdMux.HandleFunc("GET /api/teachers", handlers.GetTeachersHandler(teacherService))
-	stdMux.HandleFunc("GET /api/teachers/{username}", handlers.GetTeacherHandler(teacherService))
-	stdMux.HandleFunc("PUT /api/teachers/{username}", handlers.UpdateTeacherHandler(teacherService))
-	stdMux.HandleFunc("DELETE /api/teachers/{username}", handlers.DeleteTeacherHandler(teacherService, userSessionService))
+	stdMux.HandleFunc("/api/teachers", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.CreateTeacherHandler(teacherService, w, r)
+		case http.MethodGet:
+			handlers.GetTeachersHandler(teacherService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/teachers/{username}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.GetTeacherHandler(teacherService, w, r)
+		case http.MethodPut:
+			handlers.UpdateTeacherHandler(teacherService, w, r)
+		case http.MethodDelete:
+			handlers.DeleteTeacherHandler(teacherService, userSessionService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
 
 	//Administrator routes
-	stdMux.HandleFunc("POST /api/administrators", handlers.CreateAdministratorHandler(administratorService))
-	stdMux.HandleFunc("GET /api/administrators", handlers.GetAdministratorsHandler(administratorService))
-	stdMux.HandleFunc("GET /api/administrators/{username}", handlers.GetAdministratorHandler(administratorService))
-	stdMux.HandleFunc("PUT /api/administrators/{username}", handlers.UpdateAdministratorHandler(administratorService))
-	stdMux.HandleFunc("DELETE /api/administrators/{username}", handlers.DeleteAdministratorHandler(administratorService, userSessionService))
+	stdMux.HandleFunc("/api/administrators", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.CreateAdministratorHandler(administratorService, w, r)
+		case http.MethodGet:
+			handlers.GetAdministratorsHandler(administratorService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/administrators/{username}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.GetAdministratorHandler(administratorService, w, r)
+		case http.MethodPut:
+			handlers.UpdateAdministratorHandler(administratorService, w, r)
+		case http.MethodDelete:
+			handlers.DeleteAdministratorHandler(administratorService, userSessionService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
 
 	//Auth routes
 	stdMux.HandleFunc("/auth/login", handlers.LoginHandler(userSessionService, userAuthService))
@@ -88,26 +169,106 @@ func main() {
 	stdMux.HandleFunc("POST /auth/change-password", handlers.ChangePasswordHandler(userAuthService))
 
 	//Courses routes
-	stdMux.HandleFunc("POST /api/courses", handlers.CreateCourseHandler(courseService))
-	stdMux.HandleFunc("GET /api/courses", handlers.GetCoursesHandler(courseService))
-	stdMux.HandleFunc("GET /api/courses/{courseID}", handlers.GetCourseHandler(courseService))
-	stdMux.HandleFunc("PUT /api/courses/{courseID}", handlers.UpdateCourseHandler(courseService))
-	stdMux.HandleFunc("DELETE /api/courses/{courseID}", handlers.DeleteCourseHandler(courseService))
+	stdMux.HandleFunc("/api/courses", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.CreateCourseHandler(courseService, w, r)
+		case http.MethodGet:
+			handlers.GetCoursesHandler(courseService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/courses/{courseID}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.GetCourseHandler(courseService, w, r)
+		case http.MethodPut:
+			handlers.UpdateCourseHandler(courseService, w, r)
+		case http.MethodDelete:
+			handlers.DeleteCourseHandler(courseService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
 
 	//Majors routes
-	stdMux.HandleFunc("POST /api/majors", handlers.CreateMajorHandler(majorService))
-	stdMux.HandleFunc("GET /api/majors", handlers.GetMajorsHandler(majorService))
-	stdMux.HandleFunc("GET /api/majors/{majorID}", handlers.GetMajorHandler(majorService))
-	stdMux.HandleFunc("PUT /api/majors/{majorID}", handlers.UpdateMajorHandler(majorService))
-	stdMux.HandleFunc("DELETE /api/majors/{majorID}", handlers.DeleteMajorHandler(majorService))
-	stdMux.HandleFunc("POST /api/majors/{majorID}/courses", handlers.AddCourseToMajorHandler(majorService))
-	stdMux.HandleFunc("GET /api/majors/{majorID}/courses", handlers.GetCoursesAssoicatedWithMajorHandler(majorService))
-	stdMux.HandleFunc("DELETE /api/majors/{majorID}/courses/{courseID}", handlers.DeleteCourseFromMajorHandler(majorService))
+	stdMux.HandleFunc("/api/majors", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.CreateMajorHandler(majorService, w, r)
+		case http.MethodGet:
+			handlers.GetMajorsHandler(majorService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/majors/{majorID}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handlers.GetMajorHandler(majorService, w, r)
+		case http.MethodPut:
+			handlers.UpdateMajorHandler(majorService, w, r)
+		case http.MethodDelete:
+			handlers.DeleteMajorHandler(majorService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/majors/{majorID}/courses", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.AddCourseToMajorHandler(majorService, w, r)
+		case http.MethodGet:
+			handlers.GetCoursesAssoicatedWithMajorHandler(majorService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
+	stdMux.HandleFunc("/api/majors/{majorID}/courses/{courseID}", handlers.DeleteCourseFromMajorHandler(majorService))
 
 	//Enrollment routes
-	stdMux.HandleFunc("GET /api/enrollments/{courseID}/students", handlers.GetCoursesStudentsHandler(enrollmentsService))
-	stdMux.HandleFunc("POST /api/enrollments/{courseID}/{studentID}", handlers.EnrollStudentHandler(enrollmentsService))
-	stdMux.HandleFunc("DELETE /api/enrollments/{courseID}/{studentID}", handlers.UnenrollStudentHandler(enrollmentsService))
+	stdMux.HandleFunc("/api/enrollments/{courseID}/students", handlers.GetCoursesStudentsHandler(enrollmentsService))
+	stdMux.HandleFunc("/api/enrollments/{courseID}/{studentID}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handlers.EnrollStudentHandler(enrollmentsService, w, r)
+		case http.MethodDelete:
+			handlers.UnenrollStudentHandler(enrollmentsService, w, r)
+		case http.MethodOptions:
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "DELETE, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.WriteHeader(200)
+		default:
+			http.Error(w, "Method not allowed", http.StatusBadRequest)
+		}
+	})
 
 	//Crete auth middleware
 	authMiddleware := middleware.AuthMiddleware(redisSession)

--- a/backend/internal/handlers/admin_handler.go
+++ b/backend/internal/handlers/admin_handler.go
@@ -8,253 +8,223 @@ import (
 	"strconv"
 )
 
-func CreateAdministratorHandler(s *services.AdministratorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func CreateAdministratorHandler(s *services.AdministratorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Decode http request params
-		var administratorCreation models.AdministratorCreation
-		if err := json.NewDecoder(r.Body).Decode(&administratorCreation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		_, err := s.CreateAdministrator(administratorCreation.Username, administratorCreation.Password, administratorCreation.FirstName, administratorCreation.LastName, administratorCreation.PhoneNumber, administratorCreation.Email, administratorCreation.Office)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+	//Decode http request params
+	var administratorCreation models.AdministratorCreation
+	if err := json.NewDecoder(r.Body).Decode(&administratorCreation); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	_, err := s.CreateAdministrator(administratorCreation.Username, administratorCreation.Password, administratorCreation.FirstName, administratorCreation.LastName, administratorCreation.PhoneNumber, administratorCreation.Email, administratorCreation.Office)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
-func GetAdministratorsHandler(s *services.AdministratorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetAdministratorsHandler(s *services.AdministratorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Query params we want to take
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		usernameParam := query.Get("username")
-		firstNameParam := query.Get("first_name")
-		lastNameParam := query.Get("last_name")
-		phoneNumberParam := query.Get("phone_number")
-		emailParam := query.Get("email")
-		officeParam := query.Get("office")
+	//Query params we want to take
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	usernameParam := query.Get("username")
+	firstNameParam := query.Get("first_name")
+	lastNameParam := query.Get("last_name")
+	phoneNumberParam := query.Get("phone_number")
+	emailParam := query.Get("email")
+	officeParam := query.Get("office")
 
-		var limit *int
-		var offset *int
-		var username *string
-		var firstName *string
-		var lastName *string
-		var phoneNumber *string
-		var email *string
-		var office *string
+	var limit *int
+	var offset *int
+	var username *string
+	var firstName *string
+	var lastName *string
+	var phoneNumber *string
+	var email *string
+	var office *string
 
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if firstNameParam != "" {
-			firstName = new(string)
-			(*firstName) = firstNameParam
-		}
-		if lastNameParam != "" {
-			lastName = new(string)
-			*lastName = lastNameParam
-		}
-		if usernameParam != "" {
-			username = new(string)
-			*username = usernameParam
-		}
-		if emailParam != "" {
-			email = new(string)
-			*email = emailParam
-		}
-		if phoneNumberParam != "" {
-			phoneNumber = new(string)
-			*phoneNumber = phoneNumberParam
-		}
-		if officeParam != "" {
-			office = new(string)
-			*office = officeParam
-		}
-
-		queryParams := models.AdministratorQueryParams{
-			Limit:       limit,
-			Offset:      offset,
-			Username:    username,
-			FirstName:   firstName,
-			LastName:    lastName,
-			Email:       email,
-			PhoneNumber: phoneNumber,
-			Office:      office,
-		}
-
-		administrators, err := s.GetAdministrators(queryParams)
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(administrators); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+		limit = new(int)
+		*limit = i
 	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if firstNameParam != "" {
+		firstName = new(string)
+		(*firstName) = firstNameParam
+	}
+	if lastNameParam != "" {
+		lastName = new(string)
+		*lastName = lastNameParam
+	}
+	if usernameParam != "" {
+		username = new(string)
+		*username = usernameParam
+	}
+	if emailParam != "" {
+		email = new(string)
+		*email = emailParam
+	}
+	if phoneNumberParam != "" {
+		phoneNumber = new(string)
+		*phoneNumber = phoneNumberParam
+	}
+	if officeParam != "" {
+		office = new(string)
+		*office = officeParam
+	}
+
+	queryParams := models.AdministratorQueryParams{
+		Limit:       limit,
+		Offset:      offset,
+		Username:    username,
+		FirstName:   firstName,
+		LastName:    lastName,
+		Email:       email,
+		PhoneNumber: phoneNumber,
+		Office:      office,
+	}
+
+	administrators, err := s.GetAdministrators(queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(administrators); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func GetAdministratorHandler(s *services.AdministratorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetAdministratorHandler(s *services.AdministratorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username
-		username := r.PathValue("username")
+	//Get username
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		administrator, err := s.GetAdministrator(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(administrator); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	administrator, err := s.GetAdministrator(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(administrator); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func UpdateAdministratorHandler(administratorService *services.AdministratorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UpdateAdministratorHandler(administratorService *services.AdministratorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "PUT")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		var administratorUpdate models.AdministratorUpdate
-		username := r.PathValue("username")
+	var administratorUpdate models.AdministratorUpdate
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&administratorUpdate); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		administrator, err := administratorService.UpdateAdministrator(username, administratorUpdate)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(&administrator); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	if err := json.NewDecoder(r.Body).Decode(&administratorUpdate); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	administrator, err := administratorService.UpdateAdministrator(username, administratorUpdate)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(&administrator); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func DeleteAdministratorHandler(adminService *services.AdministratorService, userSessionService *services.UserSessionService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func DeleteAdministratorHandler(adminService *services.AdministratorService, userSessionService *services.UserSessionService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username to delete
-		username := r.PathValue("username")
-		if username == "" {
-			http.Error(w, "Administrator username not provided", http.StatusBadRequest)
-			return
-		}
-		//Revoke any active user sessions associated with the user
-		if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
-			http.Error(w, "Error occured when deleting administrator", http.StatusInternalServerError)
-			return
-		}
-		//Delete administrator
-		success, err := adminService.DeleteAdministrator(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !success {
-			http.Error(w, "Error occured when deleting administrator", http.StatusInternalServerError)
-			return
-		}
-		//Write 204 back to indicate successful deletion
-		w.WriteHeader(http.StatusNoContent)
+	//Get username to delete
+	username := r.PathValue("username")
+	if username == "" {
+		http.Error(w, "Administrator username not provided", http.StatusBadRequest)
+		return
 	}
+	//Revoke any active user sessions associated with the user
+	if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
+		http.Error(w, "Error occured when deleting administrator", http.StatusInternalServerError)
+		return
+	}
+	//Delete administrator
+	success, err := adminService.DeleteAdministrator(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !success {
+		http.Error(w, "Error occured when deleting administrator", http.StatusInternalServerError)
+		return
+	}
+	//Write 204 back to indicate successful deletion
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/handlers/course_handler.go
+++ b/backend/internal/handlers/course_handler.go
@@ -9,306 +9,276 @@ import (
 	"strconv"
 )
 
-func CreateCourseHandler(s *services.CourseService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func CreateCourseHandler(s *services.CourseService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Decode http request params
-		var courseCreation models.CourseCreation
-		if err := json.NewDecoder(r.Body).Decode(&courseCreation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		_, err := s.CreateCourse(courseCreation)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	//Decode http request params
+	var courseCreation models.CourseCreation
+	if err := json.NewDecoder(r.Body).Decode(&courseCreation); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	_, err := s.CreateCourse(courseCreation)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
 }
-func GetCoursesHandler(s *services.CourseService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetCoursesHandler(s *services.CourseService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Query params we want to take
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		nameParam := query.Get("name")
-		descriptionParam := query.Get("description")
-		teacherParam := query.Get("teacher_id")
-		maxEnrollmentParam := query.Get("max_enrollment")
-		minEnrollmentParam := query.Get("min_enrollment")
-		maxNumCreditsParam := query.Get("max_num_credits")
-		minNumCreditsParam := query.Get("min_num_credits")
-		statusParam := query.Get("status")
+	//Query params we want to take
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	nameParam := query.Get("name")
+	descriptionParam := query.Get("description")
+	teacherParam := query.Get("teacher_id")
+	maxEnrollmentParam := query.Get("max_enrollment")
+	minEnrollmentParam := query.Get("min_enrollment")
+	maxNumCreditsParam := query.Get("max_num_credits")
+	minNumCreditsParam := query.Get("min_num_credits")
+	statusParam := query.Get("status")
 
-		var limit *int
-		var offset *int
-		var name *string
-		var description *string
-		var teacherID *int
-		var maxEnrollment *int
-		var minEnrollment *int
-		var maxNumCredits *int
-		var minNumCredits *int
-		var status *string
+	var limit *int
+	var offset *int
+	var name *string
+	var description *string
+	var teacherID *int
+	var maxEnrollment *int
+	var minEnrollment *int
+	var maxNumCredits *int
+	var minNumCredits *int
+	var status *string
 
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if nameParam != "" {
-			name = new(string)
-			(*name) = nameParam
-		}
-		if descriptionParam != "" {
-			description = new(string)
-			(*description) = descriptionParam
-		}
-		if teacherParam != "" {
-			i, err := strconv.Atoi(teacherParam)
-			if err != nil {
-				http.Error(w, "Invalid teacher id param", http.StatusBadRequest)
-				return
-			}
-			teacherID = new(int)
-			*teacherID = i
-		}
-		if maxEnrollmentParam != "" {
-			i, err := strconv.Atoi(maxEnrollmentParam)
-			if err != nil {
-				http.Error(w, "Invalid max enrollment param", http.StatusBadRequest)
-				return
-			}
-			maxEnrollment = new(int)
-			*maxEnrollment = i
-		}
-		if minEnrollmentParam != "" {
-			i, err := strconv.Atoi(minEnrollmentParam)
-			if err != nil {
-				http.Error(w, "Invalid min enrollment param", http.StatusBadRequest)
-				return
-			}
-			minEnrollment = new(int)
-			*minEnrollment = i
-		}
-		if maxNumCreditsParam != "" {
-			i, err := strconv.Atoi(maxNumCreditsParam)
-			if err != nil {
-				http.Error(w, "Invalid max num credits param", http.StatusBadRequest)
-				return
-			}
-			maxNumCredits = new(int)
-			*maxNumCredits = i
-		}
-		if minNumCreditsParam != "" {
-			i, err := strconv.Atoi(minNumCreditsParam)
-			if err != nil {
-				http.Error(w, "Invalid min num credits param", http.StatusBadRequest)
-				return
-			}
-			minNumCredits = new(int)
-			*minNumCredits = i
-		}
-		if statusParam != "" {
-			status = new(string)
-			(*status) = statusParam
-		}
-
-		queryParams := models.CourseQueryParams{
-			Limit:         limit,
-			Offset:        offset,
-			Name:          name,
-			Description:   description,
-			TeacherID:     teacherID,
-			MaxEnrollment: maxEnrollment,
-			MinEnrollment: minEnrollment,
-			MaxNumCredits: maxNumCredits,
-			MinNumCredits: minNumCredits,
-			Status:        status,
-		}
-
-		courses, err := s.GetCourses(queryParams)
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(courses); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+		limit = new(int)
+		*limit = i
 	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if nameParam != "" {
+		name = new(string)
+		(*name) = nameParam
+	}
+	if descriptionParam != "" {
+		description = new(string)
+		(*description) = descriptionParam
+	}
+	if teacherParam != "" {
+		i, err := strconv.Atoi(teacherParam)
+		if err != nil {
+			http.Error(w, "Invalid teacher id param", http.StatusBadRequest)
+			return
+		}
+		teacherID = new(int)
+		*teacherID = i
+	}
+	if maxEnrollmentParam != "" {
+		i, err := strconv.Atoi(maxEnrollmentParam)
+		if err != nil {
+			http.Error(w, "Invalid max enrollment param", http.StatusBadRequest)
+			return
+		}
+		maxEnrollment = new(int)
+		*maxEnrollment = i
+	}
+	if minEnrollmentParam != "" {
+		i, err := strconv.Atoi(minEnrollmentParam)
+		if err != nil {
+			http.Error(w, "Invalid min enrollment param", http.StatusBadRequest)
+			return
+		}
+		minEnrollment = new(int)
+		*minEnrollment = i
+	}
+	if maxNumCreditsParam != "" {
+		i, err := strconv.Atoi(maxNumCreditsParam)
+		if err != nil {
+			http.Error(w, "Invalid max num credits param", http.StatusBadRequest)
+			return
+		}
+		maxNumCredits = new(int)
+		*maxNumCredits = i
+	}
+	if minNumCreditsParam != "" {
+		i, err := strconv.Atoi(minNumCreditsParam)
+		if err != nil {
+			http.Error(w, "Invalid min num credits param", http.StatusBadRequest)
+			return
+		}
+		minNumCredits = new(int)
+		*minNumCredits = i
+	}
+	if statusParam != "" {
+		status = new(string)
+		(*status) = statusParam
+	}
+
+	queryParams := models.CourseQueryParams{
+		Limit:         limit,
+		Offset:        offset,
+		Name:          name,
+		Description:   description,
+		TeacherID:     teacherID,
+		MaxEnrollment: maxEnrollment,
+		MinEnrollment: minEnrollment,
+		MaxNumCredits: maxNumCredits,
+		MinNumCredits: minNumCredits,
+		Status:        status,
+	}
+
+	courses, err := s.GetCourses(queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(courses); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func GetCourseHandler(s *services.CourseService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetCourseHandler(s *services.CourseService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get course id
-		courseIDParam := r.PathValue("courseID")
+	//Get course id
+	courseIDParam := r.PathValue("courseID")
 
-		if courseIDParam == "" {
-			http.Error(w, "Course ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		courseID, err := strconv.Atoi(courseIDParam)
-		if err != nil {
-			http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		course, err := s.GetCourse(courseID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(course); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if courseIDParam == "" {
+		http.Error(w, "Course ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	courseID, err := strconv.Atoi(courseIDParam)
+	if err != nil {
+		http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	course, err := s.GetCourse(courseID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(course); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func UpdateCourseHandler(s *services.CourseService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UpdateCourseHandler(s *services.CourseService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "PUT")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		var courseUpdate models.CourseUpdate
-		courseIDParam := r.PathValue("courseID")
+	var courseUpdate models.CourseUpdate
+	courseIDParam := r.PathValue("courseID")
 
-		if courseIDParam == "" {
-			http.Error(w, "Course ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		courseID, err := strconv.Atoi(courseIDParam)
-		if err != nil {
-			http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&courseUpdate); err != nil {
-			http.Error(w, "Error ocurred while updating course", http.StatusInternalServerError)
-			return
-		}
-
-		success, err := s.UpdateCourse(courseID, courseUpdate)
-		if err != nil {
-			if errors.Is(err, models.NoAffectedRows) {
-				http.Error(w, "No course was found to update", http.StatusNotFound)
-				return
-			}
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		if !success {
-			http.Error(w, "Error occured while updating course", http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if courseIDParam == "" {
+		http.Error(w, "Course ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	courseID, err := strconv.Atoi(courseIDParam)
+	if err != nil {
+		http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&courseUpdate); err != nil {
+		http.Error(w, "Error ocurred while updating course", http.StatusInternalServerError)
+		return
+	}
+
+	success, err := s.UpdateCourse(courseID, courseUpdate)
+	if err != nil {
+		if errors.Is(err, models.NoAffectedRows) {
+			http.Error(w, "No course was found to update", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !success {
+		http.Error(w, "Error occured while updating course", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func DeleteCourseHandler(s *services.CourseService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func DeleteCourseHandler(s *services.CourseService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get course id to delete
-		courseIDParam := r.PathValue("courseID")
+	//Get course id to delete
+	courseIDParam := r.PathValue("courseID")
 
-		if courseIDParam == "" {
-			http.Error(w, "Course ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		courseID, err := strconv.Atoi(courseIDParam)
-		if err != nil {
-			http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		//Delete course
-		success, err := s.DeleteCourse(courseID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if !success {
-			http.Error(w, "Error occured when deleting course", http.StatusBadRequest)
-			return
-		}
-		//Write 204 back to indicate successful deletion
-		w.WriteHeader(http.StatusNoContent)
+	if courseIDParam == "" {
+		http.Error(w, "Course ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	courseID, err := strconv.Atoi(courseIDParam)
+	if err != nil {
+		http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	//Delete course
+	success, err := s.DeleteCourse(courseID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !success {
+		http.Error(w, "Error occured when deleting course", http.StatusBadRequest)
+		return
+	}
+	//Write 204 back to indicate successful deletion
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/handlers/enrollments_handler.go
+++ b/backend/internal/handlers/enrollments_handler.go
@@ -7,100 +7,88 @@ import (
 	"strconv"
 )
 
-func EnrollStudentHandler(s *services.EnrollmentsService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func EnrollStudentHandler(s *services.EnrollmentsService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		courseIDParam := r.PathValue("courseID")
-		studentIDParam := r.PathValue("studentID")
+	courseIDParam := r.PathValue("courseID")
+	studentIDParam := r.PathValue("studentID")
 
-		if courseIDParam == "" {
-			http.Error(w, "Missing course id", http.StatusBadRequest)
-			return
-		}
-		if studentIDParam == "" {
-			http.Error(w, "Missing student id", http.StatusBadRequest)
-			return
-		}
-
-		courseID, err := strconv.Atoi(courseIDParam)
-		if err != nil {
-			http.Error(w, "Course id invalid format", http.StatusBadRequest)
-			return
-		}
-		studentID, err := strconv.Atoi(studentIDParam)
-		if err != nil {
-			http.Error(w, "Course id invalid format", http.StatusBadRequest)
-			return
-		}
-
-		success, err := s.EnrollStudent(courseID, studentID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !success {
-			http.Error(w, "Unable to enroll student in course", http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+	if courseIDParam == "" {
+		http.Error(w, "Missing course id", http.StatusBadRequest)
+		return
 	}
+	if studentIDParam == "" {
+		http.Error(w, "Missing student id", http.StatusBadRequest)
+		return
+	}
+
+	courseID, err := strconv.Atoi(courseIDParam)
+	if err != nil {
+		http.Error(w, "Course id invalid format", http.StatusBadRequest)
+		return
+	}
+	studentID, err := strconv.Atoi(studentIDParam)
+	if err != nil {
+		http.Error(w, "Course id invalid format", http.StatusBadRequest)
+		return
+	}
+
+	success, err := s.EnrollStudent(courseID, studentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !success {
+		http.Error(w, "Unable to enroll student in course", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
-func UnenrollStudentHandler(s *services.EnrollmentsService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UnenrollStudentHandler(s *services.EnrollmentsService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		courseIDParam := r.PathValue("courseID")
-		studentIDParam := r.PathValue("studentID")
+	courseIDParam := r.PathValue("courseID")
+	studentIDParam := r.PathValue("studentID")
 
-		if courseIDParam == "" {
-			http.Error(w, "Missing course id", http.StatusBadRequest)
-			return
-		}
-		if studentIDParam == "" {
-			http.Error(w, "Missing student id", http.StatusBadRequest)
-			return
-		}
-
-		courseID, err := strconv.Atoi(courseIDParam)
-		if err != nil {
-			http.Error(w, "Course id invalid format", http.StatusBadRequest)
-			return
-		}
-		studentID, err := strconv.Atoi(studentIDParam)
-		if err != nil {
-			http.Error(w, "Course id invalid format", http.StatusBadRequest)
-			return
-		}
-
-		success, err := s.UnenrollStudent(courseID, studentID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !success {
-			http.Error(w, "Unable to unenroll student in course", http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusNoContent)
+	if courseIDParam == "" {
+		http.Error(w, "Missing course id", http.StatusBadRequest)
+		return
 	}
+	if studentIDParam == "" {
+		http.Error(w, "Missing student id", http.StatusBadRequest)
+		return
+	}
+
+	courseID, err := strconv.Atoi(courseIDParam)
+	if err != nil {
+		http.Error(w, "Course id invalid format", http.StatusBadRequest)
+		return
+	}
+	studentID, err := strconv.Atoi(studentIDParam)
+	if err != nil {
+		http.Error(w, "Course id invalid format", http.StatusBadRequest)
+		return
+	}
+
+	success, err := s.UnenrollStudent(courseID, studentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !success {
+		http.Error(w, "Unable to unenroll student in course", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func GetCoursesStudentsHandler(s *services.EnrollmentsService) http.HandlerFunc {

--- a/backend/internal/handlers/major_handler.go
+++ b/backend/internal/handlers/major_handler.go
@@ -9,465 +9,423 @@ import (
 	"strconv"
 )
 
-func CreateMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func CreateMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Decode http request params
-		var majorCreation models.MajorCreation
-		if err := json.NewDecoder(r.Body).Decode(&majorCreation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		_, err := s.CreateMajor(majorCreation)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	//Decode http request params
+	var majorCreation models.MajorCreation
+	if err := json.NewDecoder(r.Body).Decode(&majorCreation); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	_, err := s.CreateMajor(majorCreation)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
 }
-func GetMajorsHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetMajorsHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Query params we want to take
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		nameParam := query.Get("name")
-		descriptionParam := query.Get("description")
-		statusParam := query.Get("status")
+	//Query params we want to take
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	nameParam := query.Get("name")
+	descriptionParam := query.Get("description")
+	statusParam := query.Get("status")
 
-		var limit *int
-		var offset *int
-		var name *string
-		var description *string
-		var status *string
+	var limit *int
+	var offset *int
+	var name *string
+	var description *string
+	var status *string
 
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if nameParam != "" {
-			name = new(string)
-			(*name) = nameParam
-		}
-		if descriptionParam != "" {
-			description = new(string)
-			(*description) = descriptionParam
-		}
-		if statusParam != "" {
-			status = new(string)
-			(*status) = statusParam
-		}
-
-		queryParams := models.MajorQueryParams{
-			Limit:       limit,
-			Offset:      offset,
-			Name:        name,
-			Description: description,
-			Status:      status,
-		}
-
-		majors, err := s.GetMajors(queryParams)
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(majors); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+		limit = new(int)
+		*limit = i
 	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if nameParam != "" {
+		name = new(string)
+		(*name) = nameParam
+	}
+	if descriptionParam != "" {
+		description = new(string)
+		(*description) = descriptionParam
+	}
+	if statusParam != "" {
+		status = new(string)
+		(*status) = statusParam
+	}
+
+	queryParams := models.MajorQueryParams{
+		Limit:       limit,
+		Offset:      offset,
+		Name:        name,
+		Description: description,
+		Status:      status,
+	}
+
+	majors, err := s.GetMajors(queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(majors); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func GetMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get major id
-		majorIDParam := r.PathValue("majorID")
+	//Get major id
+	majorIDParam := r.PathValue("majorID")
 
-		if majorIDParam == "" {
-			http.Error(w, "Major ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		majorID, err := strconv.Atoi(majorIDParam)
-		if err != nil {
-			http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		major, err := s.GetMajor(majorID)
-		if err != nil {
-			http.Error(w, "Unable to get major", http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(major); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if majorIDParam == "" {
+		http.Error(w, "Major ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	majorID, err := strconv.Atoi(majorIDParam)
+	if err != nil {
+		http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	major, err := s.GetMajor(majorID)
+	if err != nil {
+		http.Error(w, "Unable to get major", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(major); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func UpdateMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UpdateMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "PUT")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		var majorUpdate models.MajorUpdate
-		majorIDParam := r.PathValue("majorID")
+	var majorUpdate models.MajorUpdate
+	majorIDParam := r.PathValue("majorID")
 
-		if majorIDParam == "" {
-			http.Error(w, "Major ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		majorID, err := strconv.Atoi(majorIDParam)
-		if err != nil {
-			http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&majorUpdate); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		success, err := s.UpdateMajor(majorID, majorUpdate)
-		if err != nil {
-			if errors.Is(err, models.NoAffectedRows) {
-				http.Error(w, "No major was found to update", http.StatusNotFound)
-				return
-			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if !success {
-			http.Error(w, "Error occured while updating major", http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if majorIDParam == "" {
+		http.Error(w, "Major ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	majorID, err := strconv.Atoi(majorIDParam)
+	if err != nil {
+		http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&majorUpdate); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	success, err := s.UpdateMajor(majorID, majorUpdate)
+	if err != nil {
+		if errors.Is(err, models.NoAffectedRows) {
+			http.Error(w, "No major was found to update", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if !success {
+		http.Error(w, "Error occured while updating major", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
-func DeleteMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func DeleteMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get major id to delete
-		majorIDParam := r.PathValue("majorID")
+	//Get major id to delete
+	majorIDParam := r.PathValue("majorID")
 
-		if majorIDParam == "" {
-			http.Error(w, "Major ID not provided", http.StatusBadRequest)
-			return
-		}
-
-		majorID, err := strconv.Atoi(majorIDParam)
-		if err != nil {
-			http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		//Delete major
-		success, err := s.DeleteMajor(majorID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if !success {
-			http.Error(w, "Error occured when deleting major", http.StatusInternalServerError)
-			return
-		}
-		//Write 204 back to indicate successful deletion
-		w.WriteHeader(http.StatusNoContent)
+	if majorIDParam == "" {
+		http.Error(w, "Major ID not provided", http.StatusBadRequest)
+		return
 	}
+
+	majorID, err := strconv.Atoi(majorIDParam)
+	if err != nil {
+		http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	//Delete major
+	success, err := s.DeleteMajor(majorID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !success {
+		http.Error(w, "Error occured when deleting major", http.StatusInternalServerError)
+		return
+	}
+	//Write 204 back to indicate successful deletion
+	w.WriteHeader(http.StatusNoContent)
 }
 
-func AddCourseToMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func AddCourseToMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		majorIDParam := r.PathValue("majorID")
+	majorIDParam := r.PathValue("majorID")
 
-		if majorIDParam == "" {
-			http.Error(w, "Major ID not provided", http.StatusBadRequest)
-			return
-		}
-		majorID, err := strconv.Atoi(majorIDParam)
-		if err != nil {
-			http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		//Get course id
-		var kv map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&kv); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		courseIDParam, ok := kv["courseID"]
-		if !ok {
-			http.Error(w, "Course ID not provided in body", http.StatusBadRequest)
-			return
-		}
-		courseID, ok := courseIDParam.(float64) // by default numbers are decoded as float64 when interface{} is the value type
-		if !ok {
-			http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		success, err := s.AddCourseToMajor(majorID, int(courseID))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if !success {
-			http.Error(w, "Unable to add course to major", http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+	if majorIDParam == "" {
+		http.Error(w, "Major ID not provided", http.StatusBadRequest)
+		return
 	}
+	majorID, err := strconv.Atoi(majorIDParam)
+	if err != nil {
+		http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	//Get course id
+	var kv map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&kv); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	courseIDParam, ok := kv["courseID"]
+	if !ok {
+		http.Error(w, "Course ID not provided in body", http.StatusBadRequest)
+		return
+	}
+	courseID, ok := courseIDParam.(float64) // by default numbers are decoded as float64 when interface{} is the value type
+	if !ok {
+		http.Error(w, "Course ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	success, err := s.AddCourseToMajor(majorID, int(courseID))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !success {
+		http.Error(w, "Unable to add course to major", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
-func GetCoursesAssoicatedWithMajorHandler(s *services.MajorService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetCoursesAssoicatedWithMajorHandler(s *services.MajorService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get major id
-		majorIDParam := r.PathValue("majorID")
-		if majorIDParam == "" {
-			http.Error(w, "Major ID not provided", http.StatusBadRequest)
-			return
-		}
-		majorID, err := strconv.Atoi(majorIDParam)
-		if err != nil {
-			http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
-			return
-		}
-
-		//Get query params
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		nameParam := query.Get("name")
-		descriptionParam := query.Get("description")
-		teacherParam := query.Get("teacher_id")
-		maxEnrollmentParam := query.Get("max_enrollment")
-		minEnrollmentParam := query.Get("min_enrollment")
-		maxNumCreditsParam := query.Get("max_num_credits")
-		minNumCreditsParam := query.Get("min_num_credits")
-		statusParam := query.Get("status")
-
-		var limit *int
-		var offset *int
-		var name *string
-		var description *string
-		var teacherID *int
-		var maxEnrollment *int
-		var minEnrollment *int
-		var maxNumCredits *int
-		var minNumCredits *int
-		var status *string
-
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if nameParam != "" {
-			name = new(string)
-			(*name) = nameParam
-		}
-		if descriptionParam != "" {
-			description = new(string)
-			(*description) = descriptionParam
-		}
-		if teacherParam != "" {
-			i, err := strconv.Atoi(teacherParam)
-			if err != nil {
-				http.Error(w, "Invalid teacher id param", http.StatusBadRequest)
-				return
-			}
-			teacherID = new(int)
-			*teacherID = i
-		}
-		if maxEnrollmentParam != "" {
-			i, err := strconv.Atoi(maxEnrollmentParam)
-			if err != nil {
-				http.Error(w, "Invalid max enrollment param", http.StatusBadRequest)
-				return
-			}
-			maxEnrollment = new(int)
-			*maxEnrollment = i
-		}
-		if minEnrollmentParam != "" {
-			i, err := strconv.Atoi(minEnrollmentParam)
-			if err != nil {
-				http.Error(w, "Invalid min enrollment param", http.StatusBadRequest)
-				return
-			}
-			minEnrollment = new(int)
-			*minEnrollment = i
-		}
-		if maxNumCreditsParam != "" {
-			i, err := strconv.Atoi(maxNumCreditsParam)
-			if err != nil {
-				http.Error(w, "Invalid max num credits param", http.StatusBadRequest)
-				return
-			}
-			maxNumCredits = new(int)
-			*maxNumCredits = i
-		}
-		if minNumCreditsParam != "" {
-			i, err := strconv.Atoi(minNumCreditsParam)
-			if err != nil {
-				http.Error(w, "Invalid min num credits param", http.StatusBadRequest)
-				return
-			}
-			minNumCredits = new(int)
-			*minNumCredits = i
-		}
-		if statusParam != "" {
-			status = new(string)
-			(*status) = statusParam
-		}
-
-		queryParams := models.CourseQueryParams{
-			Limit:         limit,
-			Offset:        offset,
-			Name:          name,
-			Description:   description,
-			TeacherID:     teacherID,
-			MaxEnrollment: maxEnrollment,
-			MinEnrollment: minEnrollment,
-			MaxNumCredits: maxNumCredits,
-			MinNumCredits: minNumCredits,
-			Status:        status,
-		}
-
-		courses, err := s.GetCoursesAssociatedWithMajor(majorID, queryParams)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(courses); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	//Get major id
+	majorIDParam := r.PathValue("majorID")
+	if majorIDParam == "" {
+		http.Error(w, "Major ID not provided", http.StatusBadRequest)
+		return
 	}
+	majorID, err := strconv.Atoi(majorIDParam)
+	if err != nil {
+		http.Error(w, "Major ID not in valid format", http.StatusBadRequest)
+		return
+	}
+
+	//Get query params
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	nameParam := query.Get("name")
+	descriptionParam := query.Get("description")
+	teacherParam := query.Get("teacher_id")
+	maxEnrollmentParam := query.Get("max_enrollment")
+	minEnrollmentParam := query.Get("min_enrollment")
+	maxNumCreditsParam := query.Get("max_num_credits")
+	minNumCreditsParam := query.Get("min_num_credits")
+	statusParam := query.Get("status")
+
+	var limit *int
+	var offset *int
+	var name *string
+	var description *string
+	var teacherID *int
+	var maxEnrollment *int
+	var minEnrollment *int
+	var maxNumCredits *int
+	var minNumCredits *int
+	var status *string
+
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		limit = new(int)
+		*limit = i
+	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if nameParam != "" {
+		name = new(string)
+		(*name) = nameParam
+	}
+	if descriptionParam != "" {
+		description = new(string)
+		(*description) = descriptionParam
+	}
+	if teacherParam != "" {
+		i, err := strconv.Atoi(teacherParam)
+		if err != nil {
+			http.Error(w, "Invalid teacher id param", http.StatusBadRequest)
+			return
+		}
+		teacherID = new(int)
+		*teacherID = i
+	}
+	if maxEnrollmentParam != "" {
+		i, err := strconv.Atoi(maxEnrollmentParam)
+		if err != nil {
+			http.Error(w, "Invalid max enrollment param", http.StatusBadRequest)
+			return
+		}
+		maxEnrollment = new(int)
+		*maxEnrollment = i
+	}
+	if minEnrollmentParam != "" {
+		i, err := strconv.Atoi(minEnrollmentParam)
+		if err != nil {
+			http.Error(w, "Invalid min enrollment param", http.StatusBadRequest)
+			return
+		}
+		minEnrollment = new(int)
+		*minEnrollment = i
+	}
+	if maxNumCreditsParam != "" {
+		i, err := strconv.Atoi(maxNumCreditsParam)
+		if err != nil {
+			http.Error(w, "Invalid max num credits param", http.StatusBadRequest)
+			return
+		}
+		maxNumCredits = new(int)
+		*maxNumCredits = i
+	}
+	if minNumCreditsParam != "" {
+		i, err := strconv.Atoi(minNumCreditsParam)
+		if err != nil {
+			http.Error(w, "Invalid min num credits param", http.StatusBadRequest)
+			return
+		}
+		minNumCredits = new(int)
+		*minNumCredits = i
+	}
+	if statusParam != "" {
+		status = new(string)
+		(*status) = statusParam
+	}
+
+	queryParams := models.CourseQueryParams{
+		Limit:         limit,
+		Offset:        offset,
+		Name:          name,
+		Description:   description,
+		TeacherID:     teacherID,
+		MaxEnrollment: maxEnrollment,
+		MinEnrollment: minEnrollment,
+		MaxNumCredits: maxNumCredits,
+		MinNumCredits: minNumCredits,
+		Status:        status,
+	}
+
+	courses, err := s.GetCoursesAssociatedWithMajor(majorID, queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(courses); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 func DeleteCourseFromMajorHandler(s *services.MajorService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handlers/student_handler.go
+++ b/backend/internal/handlers/student_handler.go
@@ -8,255 +8,225 @@ import (
 	"strconv"
 )
 
-func CreateStudentHandler(s *services.StudentService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func CreateStudentHandler(s *services.StudentService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Decode http request params
-		var studentCreation models.StudentCreation
-		if err := json.NewDecoder(r.Body).Decode(&studentCreation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		_, err := s.CreateStudent(studentCreation.Username, studentCreation.Password, studentCreation.FirstName, studentCreation.LastName, studentCreation.PhoneNumber, studentCreation.Email)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+	//Decode http request params
+	var studentCreation models.StudentCreation
+	if err := json.NewDecoder(r.Body).Decode(&studentCreation); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	_, err := s.CreateStudent(studentCreation.Username, studentCreation.Password, studentCreation.FirstName, studentCreation.LastName, studentCreation.PhoneNumber, studentCreation.Email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
-func GetStudentsHandler(s *services.StudentService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetStudentsHandler(s *services.StudentService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Query params we want to take
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		usernameParam := query.Get("username")
-		firstNameParam := query.Get("first_name")
-		lastNameParam := query.Get("last_name")
-		phoneNumberParam := query.Get("phone_number")
-		majorParam := query["major"]
-		emailParam := query.Get("email")
+	//Query params we want to take
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	usernameParam := query.Get("username")
+	firstNameParam := query.Get("first_name")
+	lastNameParam := query.Get("last_name")
+	phoneNumberParam := query.Get("phone_number")
+	majorParam := query["major"]
+	emailParam := query.Get("email")
 
-		var limit *int
-		var offset *int
-		var username *string
-		var firstName *string
-		var lastName *string
-		var phoneNumber *string
-		var email *string
-		var majors *[]string
+	var limit *int
+	var offset *int
+	var username *string
+	var firstName *string
+	var lastName *string
+	var phoneNumber *string
+	var email *string
+	var majors *[]string
 
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if firstNameParam != "" {
-			firstName = new(string)
-			(*firstName) = firstNameParam
-		}
-		if lastNameParam != "" {
-			lastName = new(string)
-			*lastName = lastNameParam
-		}
-		if usernameParam != "" {
-			username = new(string)
-			*username = usernameParam
-		}
-		if emailParam != "" {
-			email = new(string)
-			*email = emailParam
-		}
-		if phoneNumberParam != "" {
-			phoneNumber = new(string)
-			*phoneNumber = phoneNumberParam
-		}
-		if len(majorParam) > 0 {
-			majors = new([]string)
-			*majors = majorParam
-		}
-
-		queryParams := models.StudentQueryParams{
-			Limit:       limit,
-			Offset:      offset,
-			Username:    username,
-			FirstName:   firstName,
-			LastName:    lastName,
-			Email:       email,
-			PhoneNumber: phoneNumber,
-			Majors:      majors,
-		}
-
-		students, err := s.GetStudents(queryParams)
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(students); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+		limit = new(int)
+		*limit = i
 	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if firstNameParam != "" {
+		firstName = new(string)
+		(*firstName) = firstNameParam
+	}
+	if lastNameParam != "" {
+		lastName = new(string)
+		*lastName = lastNameParam
+	}
+	if usernameParam != "" {
+		username = new(string)
+		*username = usernameParam
+	}
+	if emailParam != "" {
+		email = new(string)
+		*email = emailParam
+	}
+	if phoneNumberParam != "" {
+		phoneNumber = new(string)
+		*phoneNumber = phoneNumberParam
+	}
+	if len(majorParam) > 0 {
+		majors = new([]string)
+		*majors = majorParam
+	}
+
+	queryParams := models.StudentQueryParams{
+		Limit:       limit,
+		Offset:      offset,
+		Username:    username,
+		FirstName:   firstName,
+		LastName:    lastName,
+		Email:       email,
+		PhoneNumber: phoneNumber,
+		Majors:      majors,
+	}
+
+	students, err := s.GetStudents(queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(students); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func GetStudentHandler(s *services.StudentService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetStudentHandler(s *services.StudentService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username
-		username := r.PathValue("username")
+	//Get username
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		student, err := s.GetStudent(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(student); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	student, err := s.GetStudent(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(student); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func UpdateStudentHandler(studentService *services.StudentService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UpdateStudentHandler(studentService *services.StudentService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "PUT")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		var studentUpdate models.StudentUpdate
-		username := r.PathValue("username")
+	var studentUpdate models.StudentUpdate
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&studentUpdate); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		student, err := studentService.UpdateStudent(username, studentUpdate)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(&student); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	if err := json.NewDecoder(r.Body).Decode(&studentUpdate); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	student, err := studentService.UpdateStudent(username, studentUpdate)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(&student); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func DeleteStudentHandler(studentService *services.StudentService, userSessionService *services.UserSessionService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func DeleteStudentHandler(studentService *services.StudentService, userSessionService *services.UserSessionService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username to delete
-		username := r.PathValue("username")
-		if username == "" {
-			http.Error(w, "Student username not provided", http.StatusBadRequest)
-			return
-		}
-		//Revoke any active user sessions associated with the user
-		if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
-			http.Error(w, "Error occured when deleting student", http.StatusInternalServerError)
-			return
-		}
-		//Delete student
-		success, err := studentService.DeleteStudent(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !success {
-			http.Error(w, "Error occured when deleting student", http.StatusInternalServerError)
-			return
-		}
-		//Write 204 back to indicate successful deletion
-		w.WriteHeader(http.StatusNoContent)
+	//Get username to delete
+	username := r.PathValue("username")
+	if username == "" {
+		http.Error(w, "Student username not provided", http.StatusBadRequest)
+		return
 	}
+	//Revoke any active user sessions associated with the user
+	if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
+		http.Error(w, "Error occured when deleting student", http.StatusInternalServerError)
+		return
+	}
+	//Delete student
+	success, err := studentService.DeleteStudent(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !success {
+		http.Error(w, "Error occured when deleting student", http.StatusInternalServerError)
+		return
+	}
+	//Write 204 back to indicate successful deletion
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func AddStudentToMajorHandler(s *services.StudentService) http.HandlerFunc {

--- a/backend/internal/handlers/teacher_handler.go
+++ b/backend/internal/handlers/teacher_handler.go
@@ -8,253 +8,223 @@ import (
 	"strconv"
 )
 
-func CreateTeacherHandler(s *services.TeacherService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func CreateTeacherHandler(s *services.TeacherService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Decode http request params
-		var teacherCreation models.TeacherCreation
-		if err := json.NewDecoder(r.Body).Decode(&teacherCreation); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		_, err := s.CreateTeacher(teacherCreation.Username, teacherCreation.Password, teacherCreation.FirstName, teacherCreation.LastName, teacherCreation.PhoneNumber, teacherCreation.Email, teacherCreation.Office)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
+	//Decode http request params
+	var teacherCreation models.TeacherCreation
+	if err := json.NewDecoder(r.Body).Decode(&teacherCreation); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	_, err := s.CreateTeacher(teacherCreation.Username, teacherCreation.Password, teacherCreation.FirstName, teacherCreation.LastName, teacherCreation.PhoneNumber, teacherCreation.Email, teacherCreation.Office)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
-func GetTeachersHandler(s *services.TeacherService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetTeachersHandler(s *services.TeacherService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Query params we want to take
-		query := r.URL.Query()
-		limitParam := query.Get("limit")
-		pageParam := query.Get("page")
-		usernameParam := query.Get("username")
-		firstNameParam := query.Get("first_name")
-		lastNameParam := query.Get("last_name")
-		phoneNumberParam := query.Get("phone_number")
-		emailParam := query.Get("email")
-		officeParam := query.Get("office")
+	//Query params we want to take
+	query := r.URL.Query()
+	limitParam := query.Get("limit")
+	pageParam := query.Get("page")
+	usernameParam := query.Get("username")
+	firstNameParam := query.Get("first_name")
+	lastNameParam := query.Get("last_name")
+	phoneNumberParam := query.Get("phone_number")
+	emailParam := query.Get("email")
+	officeParam := query.Get("office")
 
-		var limit *int
-		var offset *int
-		var username *string
-		var firstName *string
-		var lastName *string
-		var phoneNumber *string
-		var email *string
-		var office *string
+	var limit *int
+	var offset *int
+	var username *string
+	var firstName *string
+	var lastName *string
+	var phoneNumber *string
+	var email *string
+	var office *string
 
-		//Get parameters
-		if limitParam != "" {
-			i, err := strconv.Atoi(limitParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			limit = new(int)
-			*limit = i
-		}
-		if pageParam != "" && limit != nil {
-			i, err := strconv.Atoi(pageParam)
-			if err != nil {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			}
-			//Can't have page 0. Page num starts at 1
-			if i <= 0 {
-				http.Error(w, "Invalid query parameter", http.StatusBadRequest)
-				return
-			} else if i == 1 {
-				offset = new(int)
-				*offset = 0
-			} else {
-				//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
-				offset = new(int)
-				*offset = (*limit) * (i - 1)
-			}
-		}
-		if firstNameParam != "" {
-			firstName = new(string)
-			(*firstName) = firstNameParam
-		}
-		if lastNameParam != "" {
-			lastName = new(string)
-			*lastName = lastNameParam
-		}
-		if usernameParam != "" {
-			username = new(string)
-			*username = usernameParam
-		}
-		if emailParam != "" {
-			email = new(string)
-			*email = emailParam
-		}
-		if phoneNumberParam != "" {
-			phoneNumber = new(string)
-			*phoneNumber = phoneNumberParam
-		}
-		if officeParam != "" {
-			office = new(string)
-			*office = officeParam
-		}
-
-		queryParams := models.TeacherQueryParams{
-			Limit:       limit,
-			Offset:      offset,
-			Username:    username,
-			FirstName:   firstName,
-			LastName:    lastName,
-			Email:       email,
-			PhoneNumber: phoneNumber,
-			Office:      office,
-		}
-
-		teachers, err := s.GetTeachers(queryParams)
+	//Get parameters
+	if limitParam != "" {
+		i, err := strconv.Atoi(limitParam)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
 			return
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(teachers); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+		limit = new(int)
+		*limit = i
 	}
+	if pageParam != "" && limit != nil {
+		i, err := strconv.Atoi(pageParam)
+		if err != nil {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		}
+		//Can't have page 0. Page num starts at 1
+		if i <= 0 {
+			http.Error(w, "Invalid query parameter", http.StatusBadRequest)
+			return
+		} else if i == 1 {
+			offset = new(int)
+			*offset = 0
+		} else {
+			//If we want the 3rd page with 10 records a page. We want to offset the query by 20 so limit * page - 1
+			offset = new(int)
+			*offset = (*limit) * (i - 1)
+		}
+	}
+	if firstNameParam != "" {
+		firstName = new(string)
+		(*firstName) = firstNameParam
+	}
+	if lastNameParam != "" {
+		lastName = new(string)
+		*lastName = lastNameParam
+	}
+	if usernameParam != "" {
+		username = new(string)
+		*username = usernameParam
+	}
+	if emailParam != "" {
+		email = new(string)
+		*email = emailParam
+	}
+	if phoneNumberParam != "" {
+		phoneNumber = new(string)
+		*phoneNumber = phoneNumberParam
+	}
+	if officeParam != "" {
+		office = new(string)
+		*office = officeParam
+	}
+
+	queryParams := models.TeacherQueryParams{
+		Limit:       limit,
+		Offset:      offset,
+		Username:    username,
+		FirstName:   firstName,
+		LastName:    lastName,
+		Email:       email,
+		PhoneNumber: phoneNumber,
+		Office:      office,
+	}
+
+	teachers, err := s.GetTeachers(queryParams)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(teachers); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func GetTeacherHandler(s *services.TeacherService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func GetTeacherHandler(s *services.TeacherService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username
-		username := r.PathValue("username")
+	//Get username
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		teacher, err := s.GetTeacher(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(teacher); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	teacher, err := s.GetTeacher(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(teacher); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func UpdateTeacherHandler(teacherService *services.TeacherService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func UpdateTeacherHandler(teacherService *services.TeacherService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "PUT")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		var teacherUpdate models.TeacherUpdate
-		username := r.PathValue("username")
+	var teacherUpdate models.TeacherUpdate
+	username := r.PathValue("username")
 
-		if username == "" {
-			http.Error(w, "Username not provided", http.StatusBadRequest)
-			return
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&teacherUpdate); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		teacher, err := teacherService.UpdateTeacher(username, teacherUpdate)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if err := json.NewEncoder(w).Encode(&teacher); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+	if username == "" {
+		http.Error(w, "Username not provided", http.StatusBadRequest)
+		return
 	}
+
+	if err := json.NewDecoder(r.Body).Decode(&teacherUpdate); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	teacher, err := teacherService.UpdateTeacher(username, teacherUpdate)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(&teacher); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
-func DeleteTeacherHandler(teacherService *services.TeacherService, userSessionService *services.UserSessionService) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//Set CORS
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+func DeleteTeacherHandler(teacherService *services.TeacherService, userSessionService *services.UserSessionService, w http.ResponseWriter, r *http.Request) {
+	//Set CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(200)
-			return
-		}
-		//Get username to delete
-		username := r.PathValue("username")
-		if username == "" {
-			http.Error(w, "Teacher username not provided", http.StatusBadRequest)
-			return
-		}
-		//Revoke any active user sessions associated with the user
-		if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
-			http.Error(w, "Error occured when deleting teacher", http.StatusInternalServerError)
-			return
-		}
-		//Delete teacher
-		success, err := teacherService.DeleteTeacher(username)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !success {
-			http.Error(w, "Error occured when deleting teacher", http.StatusInternalServerError)
-			return
-		}
-		//Write 204 back to indicate successful deletion
-		w.WriteHeader(http.StatusNoContent)
+	//Get username to delete
+	username := r.PathValue("username")
+	if username == "" {
+		http.Error(w, "Teacher username not provided", http.StatusBadRequest)
+		return
 	}
+	//Revoke any active user sessions associated with the user
+	if _, err := userSessionService.RevokeUserSessionWithUsername(username); err != nil {
+		http.Error(w, "Error occured when deleting teacher", http.StatusInternalServerError)
+		return
+	}
+	//Delete teacher
+	success, err := teacherService.DeleteTeacher(username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !success {
+		http.Error(w, "Error occured when deleting teacher", http.StatusInternalServerError)
+		return
+	}
+	//Write 204 back to indicate successful deletion
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
- Add switch statement for endpoints with same path but different methods. Pass ResponseWriter and Request to the handlers.
- Move OPTIONS preflight logic to the switch statements too.